### PR TITLE
:sparkles: Route for creating new view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Notes from "./views/notes";
 import Profile from "./views/profile";
 import { FETCH_NOTES_SUCCESS } from "./store/ducks/note/types";
 import { WELCOME_NOTE } from "./lib/notes";
+import NewNoteView from "./views/new-note";
 
 export default function App() {
   const { isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0();
@@ -37,6 +38,7 @@ export default function App() {
       <Route exact path="/" component={Notes} />
       <Route exact path="/notes/:id" component={Note} />
       <PrivateRoute exact path="/profile" component={Profile} />
+      <PrivateRoute exact path="/new" component={NewNoteView} />
       {!isAuthenticated ? (
         <Route exact path="/login" component={Login} />
       ) : (

--- a/src/views/new-note.tsx
+++ b/src/views/new-note.tsx
@@ -1,0 +1,28 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import React, { useState } from "react";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { createNote } from "../store/ducks/note/operation";
+
+export default function NewNoteView() {
+  const { getAccessTokenSilently } = useAuth0();
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const [isCreated, setIsCreated] = useState<boolean>(false);
+
+  useEffect(() => {
+    const createNewNote = async () => {
+      const token = await getAccessTokenSilently();
+      dispatch(createNote({ token, history }));
+    };
+
+    if (!isCreated) {
+      createNewNote();
+      setIsCreated(true);
+    }
+  }, [dispatch, getAccessTokenSilently, history, isCreated]);
+
+  return <div />;
+}


### PR DESCRIPTION
# Notable changes

- Create a new view that lives on `/new` for automatically creating a new note.